### PR TITLE
[KRYS-1085] Implement empty asset screen - Missing "Buy ETH" button

### DIFF
--- a/KyberNetwork/KyberNetwork/Screens/Tabbars/Overview/Controllers/OverviewMainViewController.swift
+++ b/KyberNetwork/KyberNetwork/Screens/Tabbars/Overview/Controllers/OverviewMainViewController.swift
@@ -830,7 +830,7 @@ extension OverviewMainViewController: UITableViewDataSource {
         cell.imageIcon.image = UIImage(named: "empty_asset_icon")
         cell.titleLabel.text = "Your balance is empty"
         cell.button1.isHidden = KNGeneralProvider.shared.currentChain != .eth
-        cell.button1.setTitle("Buy ETH", for: .normal)
+        cell.button1.setTitle("+ Buy ETH", for: .normal)
         cell.action = {
             self.navigationController?.openSafari(with: "https://krystal.app/buy-crypto.html")
         }

--- a/KyberNetwork/KyberNetwork/Screens/Tabbars/Overview/Controllers/OverviewMainViewController.swift
+++ b/KyberNetwork/KyberNetwork/Screens/Tabbars/Overview/Controllers/OverviewMainViewController.swift
@@ -829,7 +829,11 @@ extension OverviewMainViewController: UITableViewDataSource {
       case .asset:
         cell.imageIcon.image = UIImage(named: "empty_asset_icon")
         cell.titleLabel.text = "Your balance is empty"
-        cell.button1.isHidden = true
+        cell.button1.isHidden = KNGeneralProvider.shared.currentChain != .eth
+        cell.button1.setTitle("Buy ETH", for: .normal)
+        cell.action = {
+            self.navigationController?.openSafari(with: "https://krystal.app/buy-crypto.html")
+        }
         cell.button2.isHidden = true
       case .favourite:
         cell.imageIcon.image = UIImage(named: "empty_fav_token")


### PR DESCRIPTION
update button "Buy ETH" when no data source in Overview screen

RE #KRYS-1085