### PR TITLE
Fix bug not migrate unknow wallet

### DIFF
--- a/KyberNetwork/KyberNetwork/Screens/Migrating/AppMigrationManager.swift
+++ b/KyberNetwork/KyberNetwork/Screens/Migrating/AppMigrationManager.swift
@@ -35,7 +35,7 @@ class AppMigrationManager {
   
   func getUnknownWallets() -> [KNWalletObject] {
     return KNWalletStorage.shared.wallets.filter { element in
-      return element.isNeedMigration()
+      return element.storateType == 0
     }
   }
   
@@ -52,7 +52,7 @@ class AppMigrationManager {
   }
   
   private func migrateKeystoreWallets(progressCallback: @escaping (Float) -> (), completion: @escaping () -> ()) {
-    KNWalletStorage.shared.migrateDataIfNeeded(keyStore: keystore)
+    KNWalletStorage.shared.migrateUnknownWallets(keystore: keystore, walletObjects: getUnknownWallets().map { $0.clone() })
     let totalWallets = keystore.wallets.count
     var completedWallets: Int = 0
     let walletObjects = KNWalletStorage.shared.wallets

--- a/KyberNetwork/KyberNetwork/Screens/Migrating/AppMigrationManager.swift
+++ b/KyberNetwork/KyberNetwork/Screens/Migrating/AppMigrationManager.swift
@@ -33,19 +33,9 @@ class AppMigrationManager {
     return !UserDefaults.hasMigratedKeystoreWallet && !keystore.wallets.isEmpty
   }
   
-  func getUnknownWallets() -> [Wallet] {
-    let walletObjects = KNWalletStorage.shared.wallets
-    return self.keystore.wallets.filter { wallet in
-      guard let walletObject = walletObjects.first(where: { $0.address.lowercased() == wallet.address?.description.lowercased() }) else {
-        return false
-      }
-      switch wallet.type {
-      case .real:
-        let storageType = StorageType(rawValue: walletObject.storateType)
-        return storageType == .unknow
-      default:
-        return false
-      }
+  func getUnknownWallets() -> [KNWalletObject] {
+    return KNWalletStorage.shared.wallets.filter { element in
+      return element.isNeedMigration()
     }
   }
   
@@ -62,6 +52,7 @@ class AppMigrationManager {
   }
   
   private func migrateKeystoreWallets(progressCallback: @escaping (Float) -> (), completion: @escaping () -> ()) {
+    KNWalletStorage.shared.migrateDataIfNeeded(keyStore: keystore)
     let totalWallets = keystore.wallets.count
     var completedWallets: Int = 0
     let walletObjects = KNWalletStorage.shared.wallets

--- a/KyberNetwork/KyberNetwork/Screens/Migrating/MigratingWalletOperation.swift
+++ b/KyberNetwork/KyberNetwork/Screens/Migrating/MigratingWalletOperation.swift
@@ -95,7 +95,7 @@ class MigratingWalletOperation: AsyncOperation {
                 ()
               }
             }
-          case .privateKey:
+          case .privateKey, .unknow:
             let keyResult = self.keystore.exportPrivateKey(account: account)
             switch keyResult {
             case .success(let key):

--- a/KyberNetwork/KyberNetwork/Storage/KNWalletStorage.swift
+++ b/KyberNetwork/KyberNetwork/Storage/KNWalletStorage.swift
@@ -162,7 +162,6 @@ class KNWalletStorage {
   }
   
   func delete(walletAddress: String) {
-    
     if self.realm == nil { return }
     guard let obj = self.get(forPrimaryKey: walletAddress), !obj.isInvalidated else { return }
     if realm.objects(KNWalletObject.self).isInvalidated { return }
@@ -185,18 +184,22 @@ class KNWalletStorage {
     let vc = UIApplication.shared.keyWindow?.rootViewController
     vc?.displayLoading(text: "Migrating", animated: true)
     DispatchQueue.main.async {
-      clones.forEach { obj in
-        if let account = keyStore.matchWithEvmAccount(address: obj.address.lowercased()), case .success(let seeds) = keyStore.exportMnemonics(account: account) {
-          let solAddress = SolanaUtil.seedsToPublicKey(seeds)
-          obj.evmAddress = obj.address
-          obj.solanaAddress = solAddress
-        } else {
-          obj.chainType = 1
-          obj.evmAddress = obj.address
-        }
-      }
-      self.update(wallets: clones)
+      self.migrateUnknownWallets(keystore: keyStore, walletObjects: clones)
       vc?.hideLoading()
     }
+  }
+  
+  func migrateUnknownWallets(keystore: Keystore, walletObjects: [KNWalletObject]) {
+    walletObjects.forEach { obj in
+      if let account = keystore.matchWithEvmAccount(address: obj.address.lowercased()), case .success(let seeds) = keystore.exportMnemonics(account: account) {
+        let solAddress = SolanaUtil.seedsToPublicKey(seeds)
+        obj.evmAddress = obj.address
+        obj.solanaAddress = solAddress
+      } else {
+        obj.chainType = 1
+        obj.evmAddress = obj.address
+      }
+    }
+    self.update(wallets: walletObjects)
   }
 }

--- a/KyberNetwork/Utilities/UserDefaults.swift
+++ b/KyberNetwork/Utilities/UserDefaults.swift
@@ -28,4 +28,7 @@ extension UserDefaults {
   @UserDefault(key: "has_migrated_keystore_wallets", defaultValue: false)
   static var hasMigratedKeystoreWallet: Bool
   
+  @UserDefault(key: "has_migrated_unknown_keystore_wallets", defaultValue: false)
+  static var hasMigratedUnknownKeystoreWallet: Bool
+  
 }


### PR DESCRIPTION
Not fully tested. 
Steps: 
1. Install an old version, import wallet with storage type = .unknow
2. Install version 1.2.17 -> missing wallets