### PR TITLE
Fix bug crash when lock screen

### DIFF
--- a/EarnModule/EarnModule/ViewControllers/StakingPortfolioViewController.swift
+++ b/EarnModule/EarnModule/ViewControllers/StakingPortfolioViewController.swift
@@ -47,6 +47,7 @@ class StakingPortfolioViewController: InAppBrowsingViewController {
     
     let viewModel: StakingPortfolioViewModel = StakingPortfolioViewModel()
     var timer: Timer?
+    var reloadingTimer: Timer?
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -71,7 +72,10 @@ class StakingPortfolioViewController: InAppBrowsingViewController {
         }
         let currentChain = AppState.shared.currentChain
         viewModel.chainID = AppState.shared.isSelectedAllChain ? nil : currentChain.getChainId()
-        Timer.scheduledTimer(withTimeInterval: 15.0, repeats: true) { [weak self] _ in
+        reloadingTimer = Timer.scheduledTimer(withTimeInterval: 15.0, repeats: true) { [weak self] _ in
+            guard UIApplication.shared.applicationState == .active else {
+                return
+            }
             self?.viewModel.requestData(shouldShowLoading: false)
         }
     }
@@ -84,6 +88,11 @@ class StakingPortfolioViewController: InAppBrowsingViewController {
         }
         portfolioTableView.reloadData()
 		AppDependencies.tracker.track("mob_earn_portfolio", properties: ["screenid": "earn_v2"])
+    }
+    
+    deinit {
+        reloadingTimer?.invalidate()
+        reloadingTimer = nil
     }
     
     private func registerCell() {


### PR DESCRIPTION
According to this [Crashlytics report](https://console.firebase.google.com/u/0/project/krystal---production/crashlytics/app/ios:com.kyrd.krystal.ios/issues/86a8e5986d0450fdbce69a13ecda5d6a?time=last-seven-days&sessionEventKey=47b0759e2a804307b2d63c4643ef95a7_1763863885113600521), app crashes when lock screen. 

It's due to the data protection setting, realm data can not be accessed when screen is locked. 